### PR TITLE
add `allowed_drift` config option, pass to `use Guardian`, note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ config :shopifex,
   scopes: "read_inventory,write_inventory,read_products,write_products,read_orders",
   api_key: "shopifyapikey123",
   secret: "shopifyapisecret456",
-  webhook_topics: ["app/uninstalled"] # These are automatically subscribed on a store upon install
+  webhook_topics: ["app/uninstalled"], # These are automatically subscribed on a store upon install
+  allowed_drift: 10_000 # session token exp/nbf tolerance in ms (defaults to 10s)
 ```
 
 Update your `endpoint.ex` to include the custom body parser. This is necessary for HMAC validation to work.

--- a/test/shopifex/guardian_test.exs
+++ b/test/shopifex/guardian_test.exs
@@ -1,0 +1,49 @@
+defmodule Shopifex.GuardianTest do
+  use ExUnit.Case
+
+  describe "allowed_drift defaults" do
+    test "accepts tokens with nbf up to 10s in the future" do
+      future =
+        DateTime.utc_now()
+        |> DateTime.add(9)
+        |> DateTime.to_unix()
+
+      {:ok, jwt} = Guardian.Token.Jwt.create_token(Shopifex.Guardian, %{"nbf" => future})
+
+      assert {:ok, _claims} = Shopifex.Guardian.decode_and_verify(jwt)
+    end
+
+    test "accepts tokens with exp up to 10s in the past" do
+      past =
+        DateTime.utc_now()
+        |> DateTime.add(-9)
+        |> DateTime.to_unix()
+
+      {:ok, jwt} = Guardian.Token.Jwt.create_token(Shopifex.Guardian, %{"exp" => past})
+
+      assert {:ok, _claims} = Shopifex.Guardian.decode_and_verify(jwt)
+    end
+
+    test "rejects tokens with nbf more than 10s in the future" do
+      future =
+        DateTime.utc_now()
+        |> DateTime.add(11)
+        |> DateTime.to_unix()
+
+      {:ok, jwt} = Guardian.Token.Jwt.create_token(Shopifex.Guardian, %{"nbf" => future})
+
+      assert {:error, :token_not_yet_valid} = Shopifex.Guardian.decode_and_verify(jwt)
+    end
+
+    test "rejects tokens with exp more than 10s in the past" do
+      past =
+        DateTime.utc_now()
+        |> DateTime.add(-11)
+        |> DateTime.to_unix()
+
+      {:ok, jwt} = Guardian.Token.Jwt.create_token(Shopifex.Guardian, %{"exp" => past})
+
+      assert {:error, :token_expired} = Shopifex.Guardian.decode_and_verify(jwt)
+    end
+  end
+end


### PR DESCRIPTION
* session tokens encoded on client may have future `nbf` value
* Guardian correctly returns `{:error, :token_not_yet_valid}`
* Shopify-official python package added 10s of "leeway":
  https://github.com/Shopify/shopify_python_api/pull/609
